### PR TITLE
Implement keep-alive functionality

### DIFF
--- a/TOCSharp/FLAPConnection.cs
+++ b/TOCSharp/FLAPConnection.cs
@@ -185,5 +185,20 @@ namespace TOCSharp
             packet.Sequence = this.seqNo++;
             await this.socket.SendAsync(packet.ToBytes(), SocketFlags.None);
         }
+
+        /// <summary>
+        /// Send FLAP packet with the type FRAME_KEEPALIVE
+        /// </summary>
+        public async Task SendKeepAliveAsync()
+        {
+            if (this.socket == null || !this.Connected)
+            {
+                throw new InvalidOperationException("Socket is not connected");
+            }
+            await this.SendPacketAsync(new FLAPPacket
+            {
+                Frame = FLAPPacket.FRAME_KEEPALIVE
+            });
+        }
     }
 }

--- a/TOCSharp/TOCClient.cs
+++ b/TOCSharp/TOCClient.cs
@@ -354,6 +354,11 @@ namespace TOCSharp
 
         private async Task StartKeepAliveLoopAsync()
         {
+            if (this.settings.KeepAliveInterval < 5000)
+            {
+                Console.WriteLine("Keep-alive interval is too frequent!");
+                return;
+            }
             isKeepAliveLoopRunning = true;
             while(this.connection != null && this.connection.Connected)
             {

--- a/TOCSharp/TOCClientSettings.cs
+++ b/TOCSharp/TOCClientSettings.cs
@@ -6,5 +6,6 @@ namespace TOCSharp
         public ushort Port { get; set; } = FLAPConnection.DEFAULT_PORT;
         public string ClientName { get; set; } = "TOCSharp";
         public bool DebugMode { get; set; } = false;
+        public uint KeepAliveInterval { get; set; } = 120000;
     }
 }

--- a/TOCSharp/TOCClientSettings.cs
+++ b/TOCSharp/TOCClientSettings.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace TOCSharp
 {
     public class TOCClientSettings
@@ -6,6 +8,6 @@ namespace TOCSharp
         public ushort Port { get; set; } = FLAPConnection.DEFAULT_PORT;
         public string ClientName { get; set; } = "TOCSharp";
         public bool DebugMode { get; set; } = false;
-        public uint KeepAliveInterval { get; set; } = 120000;
+        public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(120);
     }
 }


### PR DESCRIPTION
This adds default behavior to send a FLAP keep-alive packet every two minutes (customizable through TOCClientSettings) to prevent the socket from closing. This behavior can be disabled by passing `client.ConnectAsync(false);` in the main program.